### PR TITLE
Use https explicitly for Forvo

### DIFF
--- a/shortcuts/o.yml
+++ b/shortcuts/o.yml
@@ -2474,7 +2474,7 @@ frsv 1:
       query: fr.sv {%1}
       created: '2023-04-10'
 frv 1:
-  url: http://{$language}.forvo.com/search/{%word}/
+  url: https://{$language}.forvo.com/search/{%word}/
   title: Forvo
   tags:
   - language


### PR DESCRIPTION
For me at least, forvo did *not* work with a `http`-URL, but works fine with exlicit `https`, so, here an extra `s`.
(I guess most other entries that have http now could be changed to https as well, but i’m not testing those at the moment. Some do work fine like this.)