### PR TITLE
Fix Forvo for English or languages without available interface

### DIFF
--- a/shortcuts/o.yml
+++ b/shortcuts/o.yml
@@ -2474,8 +2474,9 @@ frsv 1:
       query: fr.sv {%1}
       created: '2023-04-10'
 frv 1:
-  url: https://{$language}.forvo.com/search/{%word}/
+  url: https://forvo.com/search/{%word}/
   title: Forvo
+  description: Forvo pronunciation database, English interface
   tags:
   - language
   - pronunciation


### PR DESCRIPTION
Turns out, the problem i was having with the Forvo.com entry wasn’t `http` vs. `https`, but that English is the standard, so there is no en.forvo.com.