### PR TITLE
Localized Forvo interfaces

### DIFF
--- a/shortcuts/ar.yml
+++ b/shortcuts/ar.yml
@@ -70,6 +70,15 @@ fr-rvs 1:
   include:
     key: fr-ar 1
     namespace: rvs
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 it-ard 0:
   include:
     key: it-ar 0

--- a/shortcuts/bg.yml
+++ b/shortcuts/bg.yml
@@ -38,6 +38,15 @@ en-dcm 1:
   include:
     key: en-bg 1
     namespace: dcm
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 sk-dcm 0:
   include:
     key: sk-bg 0

--- a/shortcuts/ca.yml
+++ b/shortcuts/ca.yml
@@ -22,6 +22,15 @@ en-dcm 1:
   include:
     key: en-ca 1
     namespace: dcm
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 sk-dcm 0:
   include:
     key: sk-ca 0

--- a/shortcuts/cs.yml
+++ b/shortcuts/cs.yml
@@ -98,6 +98,15 @@ en-dcm 1:
   include:
     key: en-cs 1
     namespace: dcm
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 es 0:
   include:
     key: es-cs 0

--- a/shortcuts/da.yml
+++ b/shortcuts/da.yml
@@ -70,6 +70,15 @@ eo-deo 1:
   include:
     key: eo-da 1
     namespace: deo
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 gyl 1:
   url: http://ordbog.gyldendal.dk/sitecore/content/Ordbog/Home/Opslag/Resultat.aspx?lcode=DAEN&q={%ord}
   title: Gyldendals Røde Ordbøger

--- a/shortcuts/de.yml
+++ b/shortcuts/de.yml
@@ -1082,6 +1082,15 @@ frp 1:
     alternative:
       query: fr-pns {%1}
       created: '2023-04-10'
+frv 1:
+  url: https://de.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo Aussprachedatenbank, deutsches Interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    Soest: Sucht nach der Aussprache von "Soest"
 ftr 1:
   url: http://www.finanztreff.de/kurse/suche/
   post parameters:

--- a/shortcuts/el.yml
+++ b/shortcuts/el.yml
@@ -54,6 +54,15 @@ en-dcm 1:
   include:
     key: en-el 1
     namespace: dcm
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 sk-dcm 0:
   include:
     key: sk-el 0

--- a/shortcuts/es.yml
+++ b/shortcuts/es.yml
@@ -152,6 +152,15 @@ fr-rvs 1:
   include:
     key: fr-es 1
     namespace: rvs
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 last 1:
   url: http://www.last.fm/search?setlang=es&q={%artist}
   title: Last.fm

--- a/shortcuts/eu.yml
+++ b/shortcuts/eu.yml
@@ -6,3 +6,12 @@ de-pka 1:
   include:
     key: de-eu 1
     namespace: pka
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"

--- a/shortcuts/fa.yml
+++ b/shortcuts/fa.yml
@@ -14,3 +14,12 @@ de-pka 1:
   include:
     key: de-fa 1
     namespace: pka
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"

--- a/shortcuts/fi.yml
+++ b/shortcuts/fi.yml
@@ -46,6 +46,15 @@ en-dcm 1:
   include:
     key: en-fi 1
     namespace: dcm
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 sk-dcm 0:
   include:
     key: sk-fi 0

--- a/shortcuts/fr.yml
+++ b/shortcuts/fr.yml
@@ -174,6 +174,15 @@ es-rvs 1:
   include:
     key: es-fr 1
     namespace: rvs
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 he-rvs 0:
   include:
     key: he-fr 0

--- a/shortcuts/he.yml
+++ b/shortcuts/he.yml
@@ -38,6 +38,15 @@ fr-rvs 1:
   include:
     key: fr-he 1
     namespace: rvs
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 sk-dcm 0:
   include:
     key: sk-he 0

--- a/shortcuts/hi.yml
+++ b/shortcuts/hi.yml
@@ -6,3 +6,12 @@ de-pka 1:
   include:
     key: de-hi 1
     namespace: pka
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"

--- a/shortcuts/hr.yml
+++ b/shortcuts/hr.yml
@@ -54,6 +54,15 @@ en-dcm 1:
   include:
     key: en-hr 1
     namespace: dcm
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 sk-dcm 0:
   include:
     key: sk-hr 0

--- a/shortcuts/hu.yml
+++ b/shortcuts/hu.yml
@@ -54,6 +54,15 @@ en-dcm 1:
   include:
     key: en-hu 1
     namespace: dcm
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 sk-dcm 0:
   include:
     key: sk-hu 0

--- a/shortcuts/hy.yml
+++ b/shortcuts/hy.yml
@@ -6,3 +6,12 @@ de-pka 1:
   include:
     key: de-hy 1
     namespace: pka
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"

--- a/shortcuts/it.yml
+++ b/shortcuts/it.yml
@@ -90,6 +90,15 @@ fr-rvs 1:
   include:
     key: fr-it 1
     namespace: rvs
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 last 1:
   url: http://www.last.fm/search?setlang=it&q={%artist}
   title: Last.fm

--- a/shortcuts/ja.yml
+++ b/shortcuts/ja.yml
@@ -62,6 +62,15 @@ fr-rvs 1:
   include:
     key: fr-ja 1
     namespace: rvs
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 last 1:
   url: http://www.last.fm/search?setlang=ja&q={%artist}
   title: Last.fm

--- a/shortcuts/ko.yml
+++ b/shortcuts/ko.yml
@@ -38,6 +38,15 @@ fr-rvs 1:
   include:
     key: fr-ko 1
     namespace: rvs
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 last 1:
   url: http://www.last.fm/search?setlang=ko&q={%artist}
   title: Last.fm

--- a/shortcuts/lv.yml
+++ b/shortcuts/lv.yml
@@ -30,6 +30,15 @@ en-dcm 1:
   include:
     key: en-lv 1
     namespace: dcm
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 sk-dcm 0:
   include:
     key: sk-lv 0

--- a/shortcuts/nl.yml
+++ b/shortcuts/nl.yml
@@ -118,6 +118,15 @@ fr-rvs 1:
   include:
     key: fr-nl 1
     namespace: rvs
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 rijm 0:
   url: http://www.rijm.nu/
   title: Rijm.nu!

--- a/shortcuts/no.yml
+++ b/shortcuts/no.yml
@@ -46,6 +46,15 @@ en-dcm 1:
   include:
     key: en-no 1
     namespace: dcm
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 sk-dcm 0:
   include:
     key: sk-no 0

--- a/shortcuts/pa.yml
+++ b/shortcuts/pa.yml
@@ -6,3 +6,12 @@ de-pka 1:
   include:
     key: de-pa 1
     namespace: pka
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"

--- a/shortcuts/pl.yml
+++ b/shortcuts/pl.yml
@@ -110,6 +110,15 @@ fr-rvs 1:
   include:
     key: fr-pl 1
     namespace: rvs
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 fw 1:
   url: http://www.filmweb.pl/search?q={%tytuł/osoba}
   title: FilmWeb

--- a/shortcuts/pt.yml
+++ b/shortcuts/pt.yml
@@ -110,6 +110,15 @@ fr-rvs 1:
   include:
     key: fr-pt 1
     namespace: rvs
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 last 1:
   url: http://www.last.fm/search?setlang=pt&q={%artist}
   title: Last.fm

--- a/shortcuts/ro.yml
+++ b/shortcuts/ro.yml
@@ -54,6 +54,15 @@ fr-rvs 1:
   include:
     key: fr-ro 1
     namespace: rvs
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 sk-dcm 0:
   include:
     key: sk-ro 0

--- a/shortcuts/ru.yml
+++ b/shortcuts/ru.yml
@@ -90,6 +90,15 @@ fr-rvs 1:
   include:
     key: fr-ru 1
     namespace: rvs
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 last 1:
   url: http://www.last.fm/search?setlang=ru&q={%artist}
   title: Last.fm

--- a/shortcuts/sk.yml
+++ b/shortcuts/sk.yml
@@ -122,6 +122,15 @@ fr-dcm 1:
   include:
     key: fr-sk 1
     namespace: dcm
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 he-dcm 0:
   include:
     key: he-sk 0

--- a/shortcuts/sr.yml
+++ b/shortcuts/sr.yml
@@ -38,6 +38,15 @@ en-dcm 1:
   include:
     key: en-sr 1
     namespace: dcm
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 sk-dcm 0:
   include:
     key: sk-sr 0

--- a/shortcuts/sv.yml
+++ b/shortcuts/sv.yml
@@ -107,6 +107,15 @@ fr-sv 1:
     alternative:
       query: fr {%1}
       created: '2023-04-10'
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 last 1:
   url: http://www.last.fm/search?setlang=sv&q={%artist}
   title: Last.fm

--- a/shortcuts/th.yml
+++ b/shortcuts/th.yml
@@ -30,6 +30,15 @@ en-dcm 1:
   include:
     key: en-th 1
     namespace: dcm
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 sk-dcm 0:
   include:
     key: sk-th 0

--- a/shortcuts/tr.yml
+++ b/shortcuts/tr.yml
@@ -86,6 +86,15 @@ fr-rvs 1:
   include:
     key: fr-tr 1
     namespace: rvs
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 sk-dcm 0:
   include:
     key: sk-tr 0

--- a/shortcuts/uk.yml
+++ b/shortcuts/uk.yml
@@ -38,6 +38,15 @@ fr-rvs 1:
   include:
     key: fr-uk 1
     namespace: rvs
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 sk-dcm 0:
   include:
     key: sk-uk 0

--- a/shortcuts/vi.yml
+++ b/shortcuts/vi.yml
@@ -30,6 +30,15 @@ en-dcm 1:
   include:
     key: en-vi 1
     namespace: dcm
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 sk-dcm 0:
   include:
     key: sk-vi 0

--- a/shortcuts/zh.yml
+++ b/shortcuts/zh.yml
@@ -74,6 +74,15 @@ fr-rvs 1:
   include:
     key: fr-zh 1
     namespace: rvs
+frv 1:
+  url: https://{$language}.forvo.com/search/{%word}/
+  title: Forvo
+  description: Forvo pronunciation database, localized interface
+  tags:
+  - language
+  - pronunciation
+  examples:
+    berlin: Search for the pronunciation of "berlin"
 last 1:
   url: http://www.last.fm/search?setlang=zh&q={%artist}
   title: Last.fm


### PR DESCRIPTION
Use the localized interface on Forvo for the 36 languages that hav one
(That excludes English. Use forvo.com instead of en.forvo.com for English.