### PR TITLE
Change eBay Kleinanzeigen to Kleinanzeigen

### DIFF
--- a/shortcuts/.de.yml
+++ b/shortcuts/.de.yml
@@ -819,31 +819,6 @@ ebay 1:
   tags:
   - affiliate
   - old
-ek 0:
-  url: https://www.ebay-kleinanzeigen.de/
-  title: eBay Kleinanzeigen, Homepage
-  tags:
-  - ebay
-  - selling
-  - shopping
-ek 1:
-  url: https://www.ebay-kleinanzeigen.de/s-suchanfrage.html?keywords={%query}
-  title: Ebay-Kleinanzeigen
-  tags:
-  - ebay
-  - shopping
-  examples:
-  - arguments: kühlschrank
-    description: Suche nach "kühlschrank"
-ek 2:
-  url: https://www.ebay-kleinanzeigen.de/s-suchanfrage.html?keywords={%query}&locationStr={%PLZ/Ort}
-  title: Ebay-Kleinanzeigen
-  tags:
-  - ebay
-  - shopping
-  examples:
-  - arguments: kühlschrank, berlin
-    description: Suche nach "kühlschrank" in Berlin
 farnell 1:
   url: http://de.farnell.com/jsp/search/browse.jsp?N=0&Ntk=gensearch&Ntt={%query}
   title: Farnell Deutschland
@@ -4581,18 +4556,6 @@ jw 1:
   tags:
   - movies
   - series
-k+ 0:
-  url: https://www.kleinanzeigen.de/p-anzeige-aufgeben-schritt2.html
-  title: Kleinanzeigen - Anzeige aufgeben
-  tags:
-  - selling
-  - shopping
-ka 0:
-  url: https://www.kleinanzeigen.de/m-meine-anzeigen.html
-  title: Kleinanzeigen - Meine Anzeigen
-  tags:
-  - selling
-  - shopping
 kaufland 0:
   url: https://www.kaufland.de/
   title: Kaufland Online Marktplatz
@@ -4606,6 +4569,49 @@ kaufland 1:
   examples:
   - arguments: spiele
     description: Suche auf Kaufland.de nach "spiele"
+kaz 0:
+  url: https://www.kleinanzeigen.de/
+  title: Kleinanzeigen.de, Homepage
+  tags:
+  - ebay
+  - selling
+  - shopping
+kaz 1:
+  url: https://www.kleinanzeigen.de/s-suchanfrage.html?keywords={%query}
+  title: Kleinanzeigen.de
+  tags:
+  - ebay
+  - shopping
+  examples:
+  - arguments: kühlschrank
+    description: Suche nach "kühlschrank"
+kaz 2:
+  url: https://www.ebay-kleinanzeigen.de/s-suchanfrage.html?keywords={%query}&locationStr={%PLZ/Ort}
+  title: Kleinanzeigen.
+  tags:
+  - ebay
+  - shopping
+  examples:
+  - arguments: kühlschrank, berlin
+    description: Suche nach "kühlschrank" in Berlin
+kaz+ 0:
+  url: https://www.kleinanzeigen.de/p-anzeige-aufgeben-schritt2.html
+  title: Kleinanzeigen - Anzeige aufgeben
+  tags:
+  - selling
+  - shopping
+kaza 0:
+  url: https://www.kleinanzeigen.de/m-meine-anzeigen.html
+  title: Kleinanzeigen - Meine Anzeigen
+  tags:
+  - selling
+  - shopping
+kazn 0:
+  url: https://www.kleinanzeigen.de/m-nachrichten.html
+  title: Kleinanzeigen - Meine Nachrichten
+  tags:
+  - selling
+  - shopping
 kfz 1:
   url: https://www.google.de/search?hl=de&q=site%3Aautokennzeichen.info%20{%Ort/Kennzeichen}&ie=utf-8
   title: KFZ-Kennzeichen Deutschland
@@ -4636,12 +4642,6 @@ kit 1:
   examples:
   - arguments: alumni
     description: Suche nach "alumni"
-kn 0:
-  url: https://www.kleinanzeigen.de/m-nachrichten.html
-  title: Kleinanzeigen - Meine Nachrichten
-  tags:
-  - selling
-  - shopping
 koka 0:
   url: https://www.koka36.de/
   title: Koka36.de Konzertkasse

--- a/shortcuts/.de.yml
+++ b/shortcuts/.de.yml
@@ -844,20 +844,6 @@ ek 2:
   examples:
   - arguments: kühlschrank, berlin
     description: Suche nach "kühlschrank" in Berlin
-ek+ 0:
-  url: https://www.ebay-kleinanzeigen.de/p-anzeige-aufgeben-schritt2.html
-  title: eBay Kleinanzeigen - Anzeige aufgeben
-  tags:
-  - ebay
-  - selling
-  - shopping
-eka 0:
-  url: https://www.ebay-kleinanzeigen.de/m-meine-anzeigen.html
-  title: eBay Kleinanzeigen - Meine Anzeigen
-  tags:
-  - ebay
-  - selling
-  - shopping
 farnell 1:
   url: http://de.farnell.com/jsp/search/browse.jsp?N=0&Ntk=gensearch&Ntt={%query}
   title: Farnell Deutschland
@@ -4595,6 +4581,18 @@ jw 1:
   tags:
   - movies
   - series
+k+ 0:
+  url: https://www.kleinanzeigen.de/p-anzeige-aufgeben-schritt2.html
+  title: Kleinanzeigen - Anzeige aufgeben
+  tags:
+  - selling
+  - shopping
+ka 0:
+  url: https://www.kleinanzeigen.de/m-meine-anzeigen.html
+  title: Kleinanzeigen - Meine Anzeigen
+  tags:
+  - selling
+  - shopping
 kaufland 0:
   url: https://www.kaufland.de/
   title: Kaufland Online Marktplatz

--- a/shortcuts/.de.yml
+++ b/shortcuts/.de.yml
@@ -858,13 +858,6 @@ eka 0:
   - ebay
   - selling
   - shopping
-ekn 0:
-  url: https://www.ebay-kleinanzeigen.de/m-nachrichten.html
-  title: eBay Kleinanzeigen - Meine Nachrichten
-  tags:
-  - ebay
-  - selling
-  - shopping
 farnell 1:
   url: http://de.farnell.com/jsp/search/browse.jsp?N=0&Ntk=gensearch&Ntt={%query}
   title: Farnell Deutschland
@@ -4645,6 +4638,12 @@ kit 1:
   examples:
   - arguments: alumni
     description: Suche nach "alumni"
+kn 0:
+  url: https://www.kleinanzeigen.de/m-nachrichten.html
+  title: Kleinanzeigen - Meine Nachrichten
+  tags:
+  - selling
+  - shopping
 koka 0:
   url: https://www.koka36.de/
   title: Koka36.de Konzertkasse

--- a/shortcuts/.de.yml
+++ b/shortcuts/.de.yml
@@ -819,6 +819,36 @@ ebay 1:
   tags:
   - affiliate
   - old
+ek 0:
+  deprecated:
+    alternative:
+      query: kaz
+      created: '2023-10-13'
+ek 1:
+  deprecated:
+    alternative:
+      query: kaz {%1}
+      created: '2023-10-13'
+ek 2:
+  deprecated:
+    alternative:
+      query: kaz {%1}, {%2}
+      created: '2023-10-13'
+ek+ 0:
+  deprecated:
+    alternative:
+      query: kaz+
+      created: '2023-10-13'
+eka 0:
+  deprecated:
+    alternative:
+      query: kaza
+      created: '2023-10-13'
+ekn 0:
+  deprecated:
+    alternative:
+      query: kazn
+      created: '2023-10-13'
 farnell 1:
   url: http://de.farnell.com/jsp/search/browse.jsp?N=0&Ntk=gensearch&Ntt={%query}
   title: Farnell Deutschland

--- a/shortcuts/o.yml
+++ b/shortcuts/o.yml
@@ -5011,11 +5011,6 @@ km 1:
   - key: km 1
     namespace: pka
 kn 0:
-  url: https://www.kleinanzeigen.de/m-nachrichten.html
-  title: Kleinanzeigen, Nachrichten
-  tags:
-  - shopping
-kn 0:
   include:
   - key: kn 0
     namespace: pka

--- a/shortcuts/o.yml
+++ b/shortcuts/o.yml
@@ -2185,6 +2185,11 @@ eis 1:
   title: Eis-machen.de Search
   tags:
   - old
+ekn 0:
+  deprecated:
+    alternative:
+      query: .de.kazn
+      created: '2023-10-13'
 el 0:
   include:
   - key: el 0

--- a/shortcuts/o.yml
+++ b/shortcuts/o.yml
@@ -2185,12 +2185,6 @@ eis 1:
   title: Eis-machen.de Search
   tags:
   - old
-ekn 0:
-  url: https://www.ebay-kleinanzeigen.de/m-nachrichten.html
-  title: Ebay-Kleinanzeigen, Nachrichten
-  tags:
-  - ebay
-  - shopping
 el 0:
   include:
   - key: el 0
@@ -5016,6 +5010,11 @@ km 1:
   include:
   - key: km 1
     namespace: pka
+kn 0:
+  url: https://www.kleinanzeigen.de/m-nachrichten.html
+  title: Kleinanzeigen, Nachrichten
+  tags:
+  - shopping
 kn 0:
   include:
   - key: kn 0


### PR DESCRIPTION
This also changes the shortcut `ekn` to just `kn`.

`eBay` was completely removed in April 2023: https://themen.kleinanzeigen.de/medien/pressemitteilungen/kleinanzeigen-ohne-ebay-was-sich-in-kurze-andert/